### PR TITLE
Add UI Toolkit stage runtime and Visual Scripting tools

### DIFF
--- a/FUnity/Assets/FUnity/Editor/PaintToSprite.cs
+++ b/FUnity/Assets/FUnity/Editor/PaintToSprite.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEditor;
 using System.IO;
+using FUnity.Stage;
 
 namespace FUnity.Editor {
     public class PaintToSprite : EditorWindow {
@@ -84,6 +85,9 @@ namespace FUnity.Editor {
                     return;
                 }
 
+                // Stage用の定義アセットを自動生成
+                CreateStageSpriteDefinition(sprite, relativePath);
+
                 // シーン上に配置
                 GameObject obj = new GameObject("FUnitySprite");
                 var renderer = obj.AddComponent<SpriteRenderer>();
@@ -93,6 +97,19 @@ namespace FUnity.Editor {
 
                 Debug.Log("✅ Sprite created and placed in the scene!");
             }
+        }
+
+        private static void CreateStageSpriteDefinition(Sprite sprite, string spriteAssetPath) {
+            string directory = Path.GetDirectoryName(spriteAssetPath);
+            if (string.IsNullOrEmpty(directory)) return;
+
+            string definitionPath = Path.Combine(directory, sprite.name + "_StageSprite.asset");
+            var definition = ScriptableObject.CreateInstance<StageSpriteDefinition>();
+            definition.Initialize(sprite, sprite.name);
+            AssetDatabase.CreateAsset(definition, definitionPath);
+            AssetDatabase.SaveAssets();
+
+            Debug.Log($"🧩 StageSpriteDefinition created at {definitionPath}. Visual Scriptingから StageVisualScripting.Spawn を呼び出すことで配置できます。");
         }
     }
 }

--- a/FUnity/Assets/FUnity/Scripts/Stage.meta
+++ b/FUnity/Assets/FUnity/Scripts/Stage.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 98bdc38cb4b7f2843bbcf18495de45b9
+guid: 5f0b64977fa2e4a419f9010f721f393f
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageBootstrapper.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageBootstrapper.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace FUnity.Stage
+{
+    /// <summary>
+    /// Ensures that a UI Toolkit based stage is available whenever a scene is loaded.
+    /// The bootstrapper is executed automatically (both in Play Mode and builds) and
+    /// spawns a dedicated GameObject with an UIDocument + StageRuntime pair.
+    /// </summary>
+    public static class StageBootstrapper
+    {
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        private static void EnsureStage()
+        {
+            if (Object.FindObjectOfType<StageRuntime>() != null)
+            {
+                return;
+            }
+
+            var root = new GameObject("FUnity Stage");
+            Object.DontDestroyOnLoad(root);
+
+            var panelSettings = ScriptableObject.CreateInstance<PanelSettings>();
+            panelSettings.name = "FUnity Stage Panel Settings (Runtime)";
+            panelSettings.clearColor = Color.clear;
+            panelSettings.scaleMode = PanelScaleMode.ScaleWithScreenSize;
+            panelSettings.referenceResolution = new Vector2(1920f, 1080f);
+            panelSettings.match = 0.5f;
+
+            var document = root.AddComponent<UIDocument>();
+            document.panelSettings = panelSettings;
+
+            root.AddComponent<StageRuntime>();
+        }
+    }
+}

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageBootstrapper.cs.meta
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageBootstrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f6669594fbc09643afb2cb8990e0482
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageRuntime.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageRuntime.cs
@@ -1,0 +1,262 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace FUnity.Stage
+{
+    /// <summary>
+    /// Builds and manages the Scratch-like workspace using Unity UI Toolkit.
+    /// The runtime creates a two-column layout: a stage on the left and helper panels on the right.
+    /// Stage sprites are managed via <see cref="StageSpriteActor"/> instances that Visual Scripting can control.
+    /// </summary>
+    [RequireComponent(typeof(UIDocument))]
+    public sealed class StageRuntime : MonoBehaviour
+    {
+        private readonly List<StageSpriteActor> _actors = new();
+
+        private UIDocument _document = default!;
+        private VisualElement _stageRoot = default!;
+        private ScrollView _spriteList = default!;
+        private Label _instructionsLabel = default!;
+
+        public static StageRuntime? Instance { get; private set; }
+
+        /// <summary>
+        /// Width/height of the current stage content rectangle.
+        /// </summary>
+        public Vector2 StageSize => _stageRoot?.contentRect.size ?? new Vector2(960f, 540f);
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Debug.LogWarning("FUnity stage runtime already exists. Destroying duplicate instance.");
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            _document = GetComponent<UIDocument>();
+            BuildLayout();
+        }
+
+        private void OnEnable()
+        {
+            RegisterExistingActors();
+            RefreshSpriteList();
+        }
+
+        private void OnDisable()
+        {
+            foreach (var actor in _actors)
+            {
+                actor.DetachFromStage();
+            }
+
+            _actors.Clear();
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+
+        /// <summary>
+        /// Instantiate a new sprite actor on the stage at runtime.
+        /// This method is designed to be called from Visual Scripting graphs.
+        /// </summary>
+        public StageSpriteActor? SpawnSprite(StageSpriteDefinition definition)
+        {
+            if (definition == null)
+            {
+                Debug.LogWarning("SpawnSprite called with a null definition.");
+                return null;
+            }
+
+            var spriteObject = new GameObject(definition.DisplayName);
+            spriteObject.transform.SetParent(transform, false);
+
+            var actor = spriteObject.AddComponent<StageSpriteActor>();
+            actor.ApplyDefinition(definition);
+            RegisterActor(actor);
+            actor.MoveTo(definition.InitialPosition);
+            return actor;
+        }
+
+        internal void RegisterActor(StageSpriteActor actor)
+        {
+            if (_actors.Contains(actor))
+            {
+                return;
+            }
+
+            _actors.Add(actor);
+            actor.AttachToStage(_stageRoot);
+            RefreshSpriteList();
+        }
+
+        internal void UnregisterActor(StageSpriteActor actor)
+        {
+            if (_actors.Remove(actor))
+            {
+                actor.DetachFromStage();
+                RefreshSpriteList();
+            }
+        }
+
+        private void BuildLayout()
+        {
+            var root = _document.rootVisualElement;
+            root.style.flexGrow = 1f;
+            root.style.flexDirection = FlexDirection.Row;
+            root.style.backgroundColor = new StyleColor(new Color(0.11f, 0.11f, 0.13f));
+            root.style.paddingLeft = 12f;
+            root.style.paddingRight = 12f;
+            root.style.paddingTop = 12f;
+            root.style.paddingBottom = 12f;
+            root.style.gap = 12f;
+
+            var leftColumn = new VisualElement { name = "funity-left" };
+            leftColumn.style.flexGrow = 1f;
+            leftColumn.style.flexDirection = FlexDirection.Column;
+            leftColumn.style.gap = 8f;
+            root.Add(leftColumn);
+
+            var stageTitle = new Label("ステージ");
+            stageTitle.style.unityFontStyleAndWeight = FontStyle.Bold;
+            stageTitle.style.fontSize = 20f;
+            stageTitle.style.color = new StyleColor(Color.white);
+            leftColumn.Add(stageTitle);
+
+            _stageRoot = new VisualElement { name = "funity-stage" };
+            _stageRoot.style.flexGrow = 1f;
+            _stageRoot.style.minHeight = 360f;
+            _stageRoot.style.backgroundColor = new StyleColor(new Color(0.18f, 0.18f, 0.2f));
+            _stageRoot.style.borderBottomWidth = 2f;
+            _stageRoot.style.borderTopWidth = 2f;
+            _stageRoot.style.borderLeftWidth = 2f;
+            _stageRoot.style.borderRightWidth = 2f;
+            _stageRoot.style.borderBottomColor = new StyleColor(new Color(0.34f, 0.34f, 0.38f));
+            _stageRoot.style.borderTopColor = new StyleColor(new Color(0.34f, 0.34f, 0.38f));
+            _stageRoot.style.borderLeftColor = new StyleColor(new Color(0.34f, 0.34f, 0.38f));
+            _stageRoot.style.borderRightColor = new StyleColor(new Color(0.34f, 0.34f, 0.38f));
+            _stageRoot.style.position = Position.Relative;
+            _stageRoot.style.overflow = Overflow.Hidden;
+            _stageRoot.style.flexDirection = FlexDirection.Row;
+            _stageRoot.style.justifyContent = Justify.Center;
+            _stageRoot.style.alignItems = Align.Center;
+            leftColumn.Add(_stageRoot);
+
+            var spritePanelTitle = new Label("スプライト");
+            spritePanelTitle.style.unityFontStyleAndWeight = FontStyle.Bold;
+            spritePanelTitle.style.fontSize = 16f;
+            spritePanelTitle.style.color = new StyleColor(Color.white);
+            leftColumn.Add(spritePanelTitle);
+
+            _spriteList = new ScrollView { name = "funity-sprite-list" };
+            _spriteList.style.flexGrow = 0f;
+            _spriteList.style.height = 120f;
+            _spriteList.style.backgroundColor = new StyleColor(new Color(0.14f, 0.14f, 0.17f));
+            _spriteList.style.borderBottomWidth = 1f;
+            _spriteList.style.borderTopWidth = 1f;
+            _spriteList.style.borderLeftWidth = 1f;
+            _spriteList.style.borderRightWidth = 1f;
+            _spriteList.style.borderBottomColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+            _spriteList.style.borderTopColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+            _spriteList.style.borderLeftColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+            _spriteList.style.borderRightColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+            leftColumn.Add(_spriteList);
+
+            var rightColumn = new VisualElement { name = "funity-right" };
+            rightColumn.style.width = 360f;
+            rightColumn.style.flexShrink = 0f;
+            rightColumn.style.flexDirection = FlexDirection.Column;
+            rightColumn.style.gap = 8f;
+            root.Add(rightColumn);
+
+            var programmingTitle = new Label("Visual Scripting");
+            programmingTitle.style.unityFontStyleAndWeight = FontStyle.Bold;
+            programmingTitle.style.fontSize = 20f;
+            programmingTitle.style.color = new StyleColor(Color.white);
+            rightColumn.Add(programmingTitle);
+
+            _instructionsLabel = new Label(
+                "Visual Scripting Graph ウィンドウを開いて、Flow Graph でスプライトを操作してください。\n" +
+                "StageRuntime.SpawnSprite や StageSpriteActor.MoveBy などのメソッドはそのままブロックとして利用できます。");
+            _instructionsLabel.style.whiteSpace = WhiteSpace.Normal;
+            _instructionsLabel.style.fontSize = 13f;
+            _instructionsLabel.style.color = new StyleColor(new Color(0.85f, 0.85f, 0.9f));
+            _instructionsLabel.style.unityTextAlign = TextAnchor.UpperLeft;
+            _instructionsLabel.style.backgroundColor = new StyleColor(new Color(0.14f, 0.14f, 0.17f));
+            _instructionsLabel.style.paddingLeft = 12f;
+            _instructionsLabel.style.paddingRight = 12f;
+            _instructionsLabel.style.paddingTop = 12f;
+            _instructionsLabel.style.paddingBottom = 12f;
+            _instructionsLabel.style.borderBottomWidth = 1f;
+            _instructionsLabel.style.borderTopWidth = 1f;
+            _instructionsLabel.style.borderLeftWidth = 1f;
+            _instructionsLabel.style.borderRightWidth = 1f;
+            _instructionsLabel.style.borderBottomColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+            _instructionsLabel.style.borderTopColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+            _instructionsLabel.style.borderLeftColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+            _instructionsLabel.style.borderRightColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+            _instructionsLabel.style.borderRadius = 4f;
+            rightColumn.Add(_instructionsLabel);
+        }
+
+        private void RegisterExistingActors()
+        {
+            var existingActors = GetComponentsInChildren<StageSpriteActor>(true);
+            foreach (var actor in existingActors)
+            {
+                RegisterActor(actor);
+            }
+        }
+
+        private void RefreshSpriteList()
+        {
+            if (_spriteList == null)
+            {
+                return;
+            }
+
+            _spriteList.contentContainer.Clear();
+            foreach (var actor in _actors)
+            {
+                var entry = new VisualElement();
+                entry.style.flexDirection = FlexDirection.Row;
+                entry.style.alignItems = Align.Center;
+                entry.style.gap = 8f;
+                entry.style.paddingLeft = 8f;
+                entry.style.paddingRight = 8f;
+                entry.style.paddingTop = 4f;
+                entry.style.paddingBottom = 4f;
+
+                var swatch = new VisualElement();
+                swatch.style.width = 32f;
+                swatch.style.height = 32f;
+                swatch.style.borderBottomWidth = 1f;
+                swatch.style.borderTopWidth = 1f;
+                swatch.style.borderLeftWidth = 1f;
+                swatch.style.borderRightWidth = 1f;
+                swatch.style.borderBottomColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+                swatch.style.borderTopColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+                swatch.style.borderLeftColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+                swatch.style.borderRightColor = new StyleColor(new Color(0.27f, 0.27f, 0.32f));
+                swatch.style.backgroundImage = actor.CurrentBackground;
+                swatch.style.unityBackgroundImageTintColor = new StyleColor(Color.white);
+                if (!actor.HasSprite)
+                {
+                    swatch.style.backgroundColor = new StyleColor(new Color(0.45f, 0.45f, 0.5f));
+                }
+                entry.Add(swatch);
+
+                var label = new Label(actor.DisplayName);
+                label.style.color = new StyleColor(Color.white);
+                label.style.fontSize = 14f;
+                entry.Add(label);
+
+                _spriteList.contentContainer.Add(entry);
+            }
+        }
+    }
+}

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageRuntime.cs.meta
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageRuntime.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c34b76d603970f49ab6b5bbda3aaaba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteActor.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteActor.cs
@@ -1,0 +1,208 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace FUnity.Stage
+{
+    /// <summary>
+    /// Represents a sprite that is rendered inside the UI Toolkit stage.
+    /// Public API is intentionally simple so it can be consumed directly from Visual Scripting graphs.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class StageSpriteActor : MonoBehaviour
+    {
+        [SerializeField]
+        private string displayName = "Sprite";
+
+        [SerializeField]
+        private Sprite? sprite;
+
+        [SerializeField]
+        private Vector2 size = new Vector2(128f, 128f);
+
+        [SerializeField]
+        private Vector2 initialPosition = new Vector2(120f, 120f);
+
+        private VisualElement? _visualElement;
+        private Vector2 _position;
+        private StageRuntime? _runtime;
+
+        /// <summary>
+        /// Friendly name shown in the UI and Visual Scripting inspector.
+        /// </summary>
+        public string DisplayName => string.IsNullOrWhiteSpace(displayName) ? name : displayName;
+
+        /// <summary>
+        /// Current pixel position inside the stage (origin = top-left).
+        /// </summary>
+        public Vector2 Position => _position;
+
+        internal StyleBackground CurrentBackground =>
+            sprite != null
+                ? new StyleBackground(sprite)
+                : new StyleBackground { keyword = StyleKeyword.Null };
+
+        internal bool HasSprite => sprite != null;
+
+        private void Awake()
+        {
+            _position = initialPosition;
+        }
+
+        private void OnEnable()
+        {
+            _runtime = StageRuntime.Instance;
+            if (_runtime != null)
+            {
+                _runtime.RegisterActor(this);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (_runtime != null)
+            {
+                _runtime.UnregisterActor(this);
+            }
+
+            _runtime = null;
+        }
+
+        /// <summary>
+        /// Apply values from a definition ScriptableObject. Useful when spawned at runtime.
+        /// </summary>
+        public void ApplyDefinition(StageSpriteDefinition definition)
+        {
+            if (definition == null)
+            {
+                return;
+            }
+
+            displayName = definition.DisplayName;
+            sprite = definition.Sprite;
+            size = definition.Size;
+            initialPosition = definition.InitialPosition;
+        }
+
+        /// <summary>
+        /// Set a new sprite texture at runtime.
+        /// </summary>
+        public void SetSprite(Sprite? newSprite)
+        {
+            sprite = newSprite;
+            if (_visualElement != null)
+            {
+                if (newSprite != null)
+                {
+                    _visualElement.style.backgroundImage = new StyleBackground(newSprite);
+                    _visualElement.style.unityBackgroundImageTintColor = new StyleColor(Color.white);
+                    _visualElement.style.backgroundColor = new StyleColor(Color.clear);
+                }
+                else
+                {
+                    _visualElement.style.backgroundImage = new StyleBackground { keyword = StyleKeyword.Null };
+                    _visualElement.style.backgroundColor = new StyleColor(new Color(0.8f, 0.2f, 0.2f));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Directly move to a specific pixel coordinate.
+        /// </summary>
+        public void MoveTo(Vector2 position)
+        {
+            _position = position;
+            if (_visualElement != null)
+            {
+                _visualElement.style.left = position.x;
+                _visualElement.style.top = position.y;
+            }
+        }
+
+        /// <summary>
+        /// Move by the given delta (in pixels).
+        /// </summary>
+        public void MoveBy(Vector2 delta) => MoveTo(_position + delta);
+
+        /// <summary>
+        /// Resize the sprite visual.
+        /// </summary>
+        public void SetSize(Vector2 newSize)
+        {
+            size = newSize;
+            if (_visualElement != null)
+            {
+                _visualElement.style.width = newSize.x;
+                _visualElement.style.height = newSize.y;
+            }
+        }
+
+        internal void AttachToStage(VisualElement stageRoot)
+        {
+            if (stageRoot == null)
+            {
+                return;
+            }
+
+            _visualElement ??= CreateVisualElement();
+            if (_visualElement.parent != stageRoot)
+            {
+                _visualElement.RemoveFromHierarchy();
+                stageRoot.Add(_visualElement);
+            }
+
+            MoveTo(_position);
+        }
+
+        internal void DetachFromStage()
+        {
+            if (_visualElement != null)
+            {
+                _visualElement.RemoveFromHierarchy();
+            }
+        }
+
+        private VisualElement CreateVisualElement()
+        {
+            var element = new VisualElement { name = DisplayName };
+            element.style.position = Position.Absolute;
+            element.style.width = size.x;
+            element.style.height = size.y;
+            element.style.left = _position.x;
+            element.style.top = _position.y;
+            element.style.borderRadius = 8f;
+            element.style.overflow = Overflow.Hidden;
+            element.style.borderBottomWidth = 1f;
+            element.style.borderTopWidth = 1f;
+            element.style.borderLeftWidth = 1f;
+            element.style.borderRightWidth = 1f;
+            element.style.borderBottomColor = new StyleColor(new Color(0.2f, 0.2f, 0.24f));
+            element.style.borderTopColor = new StyleColor(new Color(0.2f, 0.2f, 0.24f));
+            element.style.borderLeftColor = new StyleColor(new Color(0.2f, 0.2f, 0.24f));
+            element.style.borderRightColor = new StyleColor(new Color(0.2f, 0.2f, 0.24f));
+
+            if (sprite != null)
+            {
+                element.style.backgroundImage = new StyleBackground(sprite);
+                element.style.unityBackgroundImageTintColor = new StyleColor(Color.white);
+            }
+            else
+            {
+                element.style.backgroundColor = new StyleColor(new Color(0.9f, 0.4f, 0.4f));
+            }
+
+            var nameLabel = new Label(DisplayName);
+            nameLabel.style.position = Position.Absolute;
+            nameLabel.style.bottom = 4f;
+            nameLabel.style.left = 4f;
+            nameLabel.style.color = new StyleColor(Color.white);
+            nameLabel.style.fontSize = 12f;
+            nameLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
+            nameLabel.style.unityTextOutlineColor = new StyleColor(Color.black);
+            nameLabel.style.unityTextOutlineWidth = 0.2f;
+            element.Add(nameLabel);
+
+            _visualElement = element;
+            return element;
+        }
+    }
+}

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteActor.cs.meta
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteActor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d31b0392ce6c9f4eb1b5a9f0ea92594
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteDefinition.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteDefinition.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+namespace FUnity.Stage
+{
+    /// <summary>
+    /// ScriptableObject used to describe a sprite entry that can be spawned on the stage.
+    /// </summary>
+    [CreateAssetMenu(menuName = "FUnity/Stage Sprite", fileName = "StageSpriteDefinition")]
+    public sealed class StageSpriteDefinition : ScriptableObject
+    {
+        [SerializeField]
+        private string displayName = "Sprite";
+
+        [SerializeField]
+        private Sprite? sprite;
+
+        [SerializeField]
+        private Vector2 size = new Vector2(128f, 128f);
+
+        [SerializeField]
+        private Vector2 initialPosition = new Vector2(120f, 120f);
+
+        public string DisplayName => string.IsNullOrWhiteSpace(displayName) ? name : displayName;
+        public Sprite? Sprite => sprite;
+        public Vector2 Size => size;
+        public Vector2 InitialPosition => initialPosition;
+
+        /// <summary>
+        /// Utility method called by editor tools when generating new definitions.
+        /// </summary>
+        public void Initialize(Sprite newSprite, string friendlyName)
+        {
+            sprite = newSprite;
+            displayName = string.IsNullOrWhiteSpace(friendlyName) ? newSprite.name : friendlyName;
+            size = new Vector2(newSprite.rect.width, newSprite.rect.height);
+        }
+    }
+}

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteDefinition.cs.meta
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteDefinition.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1821fd09d5d2b1f4389687e427f65532
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageVisualScripting.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageVisualScripting.cs
@@ -1,0 +1,19 @@
+namespace FUnity.Stage
+{
+    /// <summary>
+    /// Lightweight helper to make it easier to reference the stage from Visual Scripting graphs.
+    /// </summary>
+    public static class StageVisualScripting
+    {
+        /// <summary>
+        /// Returns the active stage runtime instance (if any).
+        /// </summary>
+        public static StageRuntime? GetStage() => StageRuntime.Instance;
+
+        /// <summary>
+        /// Spawn a sprite using a definition ScriptableObject.
+        /// Convenient wrapper that can be called directly from a Visual Scripting "Invoke Member" node.
+        /// </summary>
+        public static StageSpriteActor? Spawn(StageSpriteDefinition definition) => StageRuntime.Instance?.SpawnSprite(definition);
+    }
+}

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageVisualScripting.cs.meta
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageVisualScripting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 767eb3e4d3980874aa33fa35959813f4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,19 @@ Unityの **UI Toolkit** や **Visual Scripting** を活用することを目指�
 | 機能 | 内容 |
 |------|------|
 | 🎨 **エディタ拡張ペイントツール** | Unityエディタ上で絵を描いてSprite化 |
+| 🧾 **Stage Sprite定義の自動生成** | 描いたSpriteからUI Toolkit用スプライト定義を同時生成 |
 | 🌐 **unityroom公開対応** | WebGLビルドで作品を共有 |
 | 🧩 **Visual Scripting連携（予定）** | ブロックプログラミング風の操作感を提供予定 |
-| 🧰 **UI Toolkitベースの舞台（予定）** | 直感的な2D作品制作環境を提供予定 |
+| 🧰 **UI Toolkitベースの舞台** | Scratchライクなステージとスプライト一覧を自動構築 |
+
+### 🧑‍💻 Visual Scripting + UI Toolkit ステージの使い方
+
+1. **シーンを再生**すると、自動的に `FUnity Stage` GameObject が生成されます。UI Toolkitで構成されたステージ／スプライトパネル／Visual Scriptingガイドが表示されます。
+2. エディタ拡張の「Paint & Save as Sprite」で描いた画像を保存すると、Spriteと同じ場所に `*_StageSprite.asset` が生成されます。
+3. Visual Scripting Graph から `StageVisualScripting.Spawn` を呼び出し、生成した `StageSpriteDefinition` を渡すと、ステージ上にスプライトが配置されます。
+4. 生成された `StageSpriteActor` コンポーネントの `MoveBy` / `MoveTo` / `SetSprite` などのメソッドをVisual Scriptingノードから呼び出すことで、Scratchのようにスプライトを動かせます。
+
+> 📌 Stageは `StageBootstrapper` により自動生成されるため、既存のシーンを編集する必要はありません。プレイモードに入るだけでScratch風ワークスペースが立ち上がります。
 
 ---
 


### PR DESCRIPTION
## Summary
- add a runtime bootstrapper that spawns a UI Toolkit based stage workspace at play time
- introduce stage sprite actors/definitions plus helpers that Visual Scripting graphs can control
- extend the paint tool to generate stage sprite definitions automatically and document the new workflow

## Testing
- not run (Unity tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e3ccdf9664832b89da90d663563cc7