### PR TITLE
Fix PanelSettings clear color assignment

### DIFF
--- a/FUnity/Assets/FUnity/Scripts/Stage/StageBootstrapper.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageBootstrapper.cs
@@ -23,7 +23,8 @@ namespace FUnity.Stage
 
             var panelSettings = ScriptableObject.CreateInstance<PanelSettings>();
             panelSettings.name = "FUnity Stage Panel Settings (Runtime)";
-            panelSettings.clearColor = Color.clear;
+            panelSettings.clearColor = true;
+            panelSettings.clearColorValue = Color.clear;
             panelSettings.scaleMode = PanelScaleMode.ScaleWithScreenSize;
             panelSettings.referenceResolution = new Vector2(1920f, 1080f);
             panelSettings.match = 0.5f;


### PR DESCRIPTION
## Summary
- correct the PanelSettings clear color configuration in `StageBootstrapper`
- explicitly enable color clearing and set the clear color to transparent

## Testing
- not run (Unity editor build not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3d1622164832bbebedba283ca22dd