### PR TITLE
Use UI Toolkit assets for stage layout

### DIFF
--- a/FUnity/Assets/FUnity/UI.meta
+++ b/FUnity/Assets/FUnity/UI.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9837bce9dc1e4e56a3526b3a6b431e0c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/FUnity/Assets/FUnity/UI/Stage.meta
+++ b/FUnity/Assets/FUnity/UI/Stage.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2831500a5b6a4b959d967376297abefc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/FUnity/Assets/FUnity/UI/Stage/Resources.meta
+++ b/FUnity/Assets/FUnity/UI/Stage/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fa961a4c977743378373e24c05e62b91
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/FUnity/Assets/FUnity/UI/Stage/Resources/Stage.meta
+++ b/FUnity/Assets/FUnity/UI/Stage/Resources/Stage.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 95264f7ed7fe405d964007df43bf88b8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/FUnity/Assets/FUnity/UI/Stage/Resources/Stage/StageLayout.uxml
+++ b/FUnity/Assets/FUnity/UI/Stage/Resources/Stage/StageLayout.uxml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements">
+    <ui:VisualElement class="funity-root">
+        <ui:VisualElement name="funity-left" class="funity-column funity-left-column">
+            <ui:Label text="ステージ" class="funity-title" />
+            <ui:VisualElement name="funity-stage" class="funity-stage" />
+            <ui:Label text="スプライト" class="funity-subtitle" />
+            <ui:ScrollView name="funity-sprite-list" class="funity-sprite-list" />
+        </ui:VisualElement>
+        <ui:VisualElement name="funity-right" class="funity-column funity-right-column">
+            <ui:Label text="Visual Scripting" class="funity-title" />
+            <ui:Label name="funity-instructions"
+                      class="funity-instructions"
+                      text="Visual Scripting Graph ウィンドウを開いて、Flow Graph でスプライトを操作してください。&#10;StageRuntime.SpawnSprite や StageSpriteActor.MoveBy などのメソッドはそのままブロックとして利用できます。" />
+        </ui:VisualElement>
+    </ui:VisualElement>
+</ui:UXML>

--- a/FUnity/Assets/FUnity/UI/Stage/Resources/Stage/StageLayout.uxml.meta
+++ b/FUnity/Assets/FUnity/UI/Stage/Resources/Stage/StageLayout.uxml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 83fe1ed61f66488e9fe8d017c604dcf4
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/FUnity/Assets/FUnity/UI/Stage/Resources/Stage/StageStyles.uss
+++ b/FUnity/Assets/FUnity/UI/Stage/Resources/Stage/StageStyles.uss
@@ -1,0 +1,121 @@
+.funity-root {
+    flex-grow: 1;
+    flex-direction: row;
+    background-color: rgba(28, 28, 33, 1);
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    gap: 12px;
+}
+
+.funity-column {
+    flex-direction: column;
+    gap: 8px;
+}
+
+.funity-left-column {
+    flex-grow: 1;
+}
+
+.funity-right-column {
+    width: 360px;
+    flex-shrink: 0;
+}
+
+.funity-title {
+    unity-font-style: bold;
+    font-size: 20px;
+    color: white;
+}
+
+.funity-subtitle {
+    unity-font-style: bold;
+    font-size: 16px;
+    color: white;
+}
+
+.funity-stage {
+    flex-grow: 1;
+    min-height: 360px;
+    background-color: rgba(46, 46, 51, 1);
+    border-bottom-width: 2px;
+    border-top-width: 2px;
+    border-left-width: 2px;
+    border-right-width: 2px;
+    border-bottom-color: rgba(87, 87, 97, 1);
+    border-top-color: rgba(87, 87, 97, 1);
+    border-left-color: rgba(87, 87, 97, 1);
+    border-right-color: rgba(87, 87, 97, 1);
+    position: relative;
+    overflow: hidden;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+}
+
+.funity-sprite-list {
+    flex-grow: 0;
+    height: 120px;
+    background-color: rgba(36, 36, 43, 1);
+    border-bottom-width: 1px;
+    border-top-width: 1px;
+    border-left-width: 1px;
+    border-right-width: 1px;
+    border-bottom-color: rgba(69, 69, 82, 1);
+    border-top-color: rgba(69, 69, 82, 1);
+    border-left-color: rgba(69, 69, 82, 1);
+    border-right-color: rgba(69, 69, 82, 1);
+}
+
+.funity-instructions {
+    white-space: normal;
+    font-size: 13px;
+    color: rgba(217, 217, 230, 1);
+    unity-text-align: upper-left;
+    background-color: rgba(36, 36, 43, 1);
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    border-bottom-width: 1px;
+    border-top-width: 1px;
+    border-left-width: 1px;
+    border-right-width: 1px;
+    border-bottom-color: rgba(69, 69, 82, 1);
+    border-top-color: rgba(69, 69, 82, 1);
+    border-left-color: rgba(69, 69, 82, 1);
+    border-right-color: rgba(69, 69, 82, 1);
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+}
+
+.funity-sprite-entry {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+}
+
+.funity-sprite-swatch {
+    width: 32px;
+    height: 32px;
+    border-bottom-width: 1px;
+    border-top-width: 1px;
+    border-left-width: 1px;
+    border-right-width: 1px;
+    border-bottom-color: rgba(69, 69, 82, 1);
+    border-top-color: rgba(69, 69, 82, 1);
+    border-left-color: rgba(69, 69, 82, 1);
+    border-right-color: rgba(69, 69, 82, 1);
+}
+
+.funity-sprite-label {
+    color: white;
+    font-size: 14px;
+}

--- a/FUnity/Assets/FUnity/UI/Stage/Resources/Stage/StageStyles.uss.meta
+++ b/FUnity/Assets/FUnity/UI/Stage/Resources/Stage/StageStyles.uss.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 57085109b48e49b28d028c13f79d2c99
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- replace the programmatic stage construction with loading a predefined UI Toolkit layout and stylesheet
- add StageLayout.uxml and StageStyles.uss resources (with meta files) so the stage can be reused across play sessions

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3d6b8dc30832b88941b6e3c819788