### PR TITLE
Prefix member variables with m_

### DIFF
--- a/FUnity/Assets/FUnity/Editor/PaintToSprite.cs
+++ b/FUnity/Assets/FUnity/Editor/PaintToSprite.cs
@@ -5,8 +5,8 @@ using FUnity.Stage;
 
 namespace FUnity.Editor {
     public class PaintToSprite : EditorWindow {
-        private Texture2D _canvasTexture;
-        private int _canvasSize = 256;
+        private Texture2D m_canvasTexture;
+        private int m_canvasSize = 256;
 
         [MenuItem("FUnity/Paint & Save as Sprite")]
         public static void ShowWindow() {
@@ -16,8 +16,8 @@ namespace FUnity.Editor {
         }
 
         private void OnEnable() {
-            if (_canvasTexture == null) {
-                _canvasTexture = new Texture2D(_canvasSize, _canvasSize, TextureFormat.RGBA32, false);
+            if (m_canvasTexture == null) {
+                m_canvasTexture = new Texture2D(m_canvasSize, m_canvasSize, TextureFormat.RGBA32, false);
                 ClearCanvas();
             }
         }
@@ -26,8 +26,8 @@ namespace FUnity.Editor {
             GUILayout.Label("🎨 Draw your Sprite", EditorStyles.boldLabel);
 
             // 描画領域
-            Rect drawArea = GUILayoutUtility.GetRect(_canvasSize, _canvasSize, GUILayout.ExpandWidth(false));
-            GUI.DrawTexture(drawArea, _canvasTexture);
+            Rect drawArea = GUILayoutUtility.GetRect(m_canvasSize, m_canvasSize, GUILayout.ExpandWidth(false));
+            GUI.DrawTexture(drawArea, m_canvasTexture);
 
             HandleMouse(drawArea);
 
@@ -40,25 +40,25 @@ namespace FUnity.Editor {
             Event e = Event.current;
             if (e.type == EventType.MouseDrag && area.Contains(e.mousePosition)) {
                 Vector2 local = e.mousePosition - new Vector2(area.x, area.y);
-                Vector2Int pixel = new Vector2Int((int)local.x, _canvasSize - (int)local.y);
-                _canvasTexture.SetPixel(pixel.x, pixel.y, Color.black);
-                _canvasTexture.Apply();
+                Vector2Int pixel = new Vector2Int((int)local.x, m_canvasSize - (int)local.y);
+                m_canvasTexture.SetPixel(pixel.x, pixel.y, Color.black);
+                m_canvasTexture.Apply();
                 e.Use();
             }
         }
 
         private void ClearCanvas() {
-            Color[] pixels = new Color[_canvasSize * _canvasSize];
+            Color[] pixels = new Color[m_canvasSize * m_canvasSize];
             for (int i = 0; i < pixels.Length; i++) pixels[i] = Color.clear;
-            _canvasTexture.SetPixels(pixels);
-            _canvasTexture.Apply();
+            m_canvasTexture.SetPixels(pixels);
+            m_canvasTexture.Apply();
         }
 
         private void SaveAsSprite() {
             string path = EditorUtility.SaveFilePanel("Save Sprite", "Assets", "MyDrawing", "png");
             if (string.IsNullOrEmpty(path)) return;
 
-            byte[] bytes = _canvasTexture.EncodeToPNG();
+            byte[] bytes = m_canvasTexture.EncodeToPNG();
             File.WriteAllBytes(path, bytes);
 
             AssetDatabase.Refresh();

--- a/FUnity/Assets/FUnity/Editor/PaintWindow.cs
+++ b/FUnity/Assets/FUnity/Editor/PaintWindow.cs
@@ -3,10 +3,10 @@ using UnityEditor;
 
 namespace FUnity.Editor {
     public class PaintWindow : EditorWindow {
-        private Texture2D _canvasTexture;
-        private Color _drawColor = Color.black;
-        private Vector2Int _lastPixelPos = new Vector2Int(-1, -1);
-        private int _canvasSize = 256;
+        private Texture2D m_canvasTexture;
+        private Color m_drawColor = Color.black;
+        private Vector2Int m_lastPixelPos = new Vector2Int(-1, -1);
+        private int m_canvasSize = 256;
 
         [MenuItem("FUnity/Paint Window")]
         public static void ShowWindow() {
@@ -16,8 +16,8 @@ namespace FUnity.Editor {
         }
 
         private void OnEnable() {
-            if (_canvasTexture == null) {
-                _canvasTexture = new Texture2D(_canvasSize, _canvasSize, TextureFormat.RGBA32, false);
+            if (m_canvasTexture == null) {
+                m_canvasTexture = new Texture2D(m_canvasSize, m_canvasSize, TextureFormat.RGBA32, false);
                 ClearCanvas();
             }
         }
@@ -26,11 +26,11 @@ namespace FUnity.Editor {
             GUILayout.Label("🎨 FUnity Paint Tool", EditorStyles.boldLabel);
 
             // 色選択
-            _drawColor = EditorGUILayout.ColorField("Draw Color", _drawColor);
+            m_drawColor = EditorGUILayout.ColorField("Draw Color", m_drawColor);
 
             // キャンバス描画
-            Rect drawArea = GUILayoutUtility.GetRect(_canvasSize, _canvasSize, GUILayout.ExpandWidth(false));
-            GUI.DrawTexture(drawArea, _canvasTexture);
+            Rect drawArea = GUILayoutUtility.GetRect(m_canvasSize, m_canvasSize, GUILayout.ExpandWidth(false));
+            GUI.DrawTexture(drawArea, m_canvasTexture);
 
             HandleMouseInput(drawArea);
 
@@ -44,28 +44,28 @@ namespace FUnity.Editor {
             Event e = Event.current;
             if (e.type == EventType.MouseDrag && drawArea.Contains(e.mousePosition)) {
                 Vector2 localPos = e.mousePosition - new Vector2(drawArea.x, drawArea.y);
-                Vector2Int pixelPos = new Vector2Int((int)localPos.x, _canvasSize - (int)localPos.y);
+                Vector2Int pixelPos = new Vector2Int((int)localPos.x, m_canvasSize - (int)localPos.y);
 
                 DrawPixel(pixelPos);
-                _lastPixelPos = pixelPos;
+                m_lastPixelPos = pixelPos;
                 e.Use();
             }
             else if (e.type == EventType.MouseUp) {
-                _lastPixelPos = new Vector2Int(-1, -1);
+                m_lastPixelPos = new Vector2Int(-1, -1);
             }
         }
 
         private void DrawPixel(Vector2Int pos) {
-            if (pos.x < 0 || pos.x >= _canvasSize || pos.y < 0 || pos.y >= _canvasSize) return;
-            _canvasTexture.SetPixel(pos.x, pos.y, _drawColor);
-            _canvasTexture.Apply();
+            if (pos.x < 0 || pos.x >= m_canvasSize || pos.y < 0 || pos.y >= m_canvasSize) return;
+            m_canvasTexture.SetPixel(pos.x, pos.y, m_drawColor);
+            m_canvasTexture.Apply();
         }
 
         private void ClearCanvas() {
-            Color[] pixels = new Color[_canvasSize * _canvasSize];
+            Color[] pixels = new Color[m_canvasSize * m_canvasSize];
             for (int i = 0; i < pixels.Length; i++) pixels[i] = Color.white;
-            _canvasTexture.SetPixels(pixels);
-            _canvasTexture.Apply();
+            m_canvasTexture.SetPixels(pixels);
+            m_canvasTexture.Apply();
         }
     }
 }

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageRuntime.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageRuntime.cs
@@ -12,21 +12,21 @@ namespace FUnity.Stage
     [RequireComponent(typeof(UIDocument))]
     public sealed class StageRuntime : MonoBehaviour
     {
-        private readonly List<StageSpriteActor> _actors = new();
+        private readonly List<StageSpriteActor> m_actors = new();
 
         private const string LayoutResourcePath = "Stage/StageLayout";
         private const string StyleResourcePath = "Stage/StageStyles";
 
-        private UIDocument _document = default!;
-        private VisualElement? _stageRoot;
-        private ScrollView? _spriteList;
+        private UIDocument m_document = default!;
+        private VisualElement? m_stageRoot;
+        private ScrollView? m_spriteList;
 
         public static StageRuntime? Instance { get; private set; }
 
         /// <summary>
         /// Width/height of the current stage content rectangle.
         /// </summary>
-        public Vector2 StageSize => _stageRoot?.contentRect.size ?? new Vector2(960f, 540f);
+        public Vector2 StageSize => m_stageRoot?.contentRect.size ?? new Vector2(960f, 540f);
 
         private void Awake()
         {
@@ -38,7 +38,7 @@ namespace FUnity.Stage
             }
 
             Instance = this;
-            _document = GetComponent<UIDocument>();
+            m_document = GetComponent<UIDocument>();
             LoadLayout();
             CacheLayoutReferences();
         }
@@ -51,12 +51,12 @@ namespace FUnity.Stage
 
         private void OnDisable()
         {
-            foreach (var actor in _actors)
+            foreach (var actor in m_actors)
             {
                 actor.DetachFromStage();
             }
 
-            _actors.Clear();
+            m_actors.Clear();
             if (Instance == this)
             {
                 Instance = null;
@@ -87,25 +87,25 @@ namespace FUnity.Stage
 
         internal void RegisterActor(StageSpriteActor actor)
         {
-            if (_actors.Contains(actor))
+            if (m_actors.Contains(actor))
             {
                 return;
             }
 
-            _actors.Add(actor);
-            if (_stageRoot == null)
+            m_actors.Add(actor);
+            if (m_stageRoot == null)
             {
                 Debug.LogError("Stage root is missing. Ensure StageLayout.uxml is loaded correctly.");
                 return;
             }
 
-            actor.AttachToStage(_stageRoot);
+            actor.AttachToStage(m_stageRoot);
             RefreshSpriteList();
         }
 
         internal void UnregisterActor(StageSpriteActor actor)
         {
-            if (_actors.Remove(actor))
+            if (m_actors.Remove(actor))
             {
                 actor.DetachFromStage();
                 RefreshSpriteList();
@@ -114,7 +114,7 @@ namespace FUnity.Stage
 
         private void LoadLayout()
         {
-            var root = _document.rootVisualElement;
+            var root = m_document.rootVisualElement;
             root.Clear();
 
             var layout = Resources.Load<VisualTreeAsset>(LayoutResourcePath);
@@ -138,15 +138,15 @@ namespace FUnity.Stage
 
         private void CacheLayoutReferences()
         {
-            var root = _document.rootVisualElement;
-            _stageRoot = root.Q<VisualElement>("funity-stage");
-            _spriteList = root.Q<ScrollView>("funity-sprite-list");
-            if (_stageRoot == null)
+            var root = m_document.rootVisualElement;
+            m_stageRoot = root.Q<VisualElement>("funity-stage");
+            m_spriteList = root.Q<ScrollView>("funity-sprite-list");
+            if (m_stageRoot == null)
             {
                 Debug.LogError("Stage root element not found in loaded UXML. Stage functionality will be limited.");
             }
 
-            if (_spriteList == null)
+            if (m_spriteList == null)
             {
                 Debug.LogError("Sprite list element not found in loaded UXML. Sprite overview will be disabled.");
             }
@@ -163,13 +163,13 @@ namespace FUnity.Stage
 
         private void RefreshSpriteList()
         {
-            if (_spriteList == null)
+            if (m_spriteList == null)
             {
                 return;
             }
 
-            _spriteList.contentContainer.Clear();
-            foreach (var actor in _actors)
+            m_spriteList.contentContainer.Clear();
+            foreach (var actor in m_actors)
             {
                 var entry = new VisualElement();
                 entry.AddToClassList("funity-sprite-entry");
@@ -188,7 +188,7 @@ namespace FUnity.Stage
                 label.AddToClassList("funity-sprite-label");
                 entry.Add(label);
 
-                _spriteList.contentContainer.Add(entry);
+                m_spriteList.contentContainer.Add(entry);
             }
         }
     }

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteActor.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteActor.cs
@@ -11,60 +11,60 @@ namespace FUnity.Stage
     public sealed class StageSpriteActor : MonoBehaviour
     {
         [SerializeField]
-        private string displayName = "Sprite";
+        private string m_displayName = "Sprite";
 
         [SerializeField]
-        private Sprite? sprite;
+        private Sprite? m_sprite;
 
         [SerializeField]
-        private Vector2 size = new Vector2(128f, 128f);
+        private Vector2 m_size = new Vector2(128f, 128f);
 
         [SerializeField]
-        private Vector2 initialPosition = new Vector2(120f, 120f);
+        private Vector2 m_initialPosition = new Vector2(120f, 120f);
 
-        private VisualElement? _visualElement;
-        private Vector2 _position;
-        private StageRuntime? _runtime;
+        private VisualElement? m_visualElement;
+        private Vector2 m_position;
+        private StageRuntime? m_runtime;
 
         /// <summary>
         /// Friendly name shown in the UI and Visual Scripting inspector.
         /// </summary>
-        public string DisplayName => string.IsNullOrWhiteSpace(displayName) ? name : displayName;
+        public string DisplayName => string.IsNullOrWhiteSpace(m_displayName) ? name : m_displayName;
 
         /// <summary>
         /// Current pixel position inside the stage (origin = top-left).
         /// </summary>
-        public Vector2 Position => _position;
+        public Vector2 Position => m_position;
 
         internal StyleBackground CurrentBackground =>
-            sprite != null
-                ? new StyleBackground(sprite)
+            m_sprite != null
+                ? new StyleBackground(m_sprite)
                 : new StyleBackground { keyword = StyleKeyword.Null };
 
-        internal bool HasSprite => sprite != null;
+        internal bool HasSprite => m_sprite != null;
 
         private void Awake()
         {
-            _position = initialPosition;
+            m_position = m_initialPosition;
         }
 
         private void OnEnable()
         {
-            _runtime = StageRuntime.Instance;
-            if (_runtime != null)
+            m_runtime = StageRuntime.Instance;
+            if (m_runtime != null)
             {
-                _runtime.RegisterActor(this);
+                m_runtime.RegisterActor(this);
             }
         }
 
         private void OnDisable()
         {
-            if (_runtime != null)
+            if (m_runtime != null)
             {
-                _runtime.UnregisterActor(this);
+                m_runtime.UnregisterActor(this);
             }
 
-            _runtime = null;
+            m_runtime = null;
         }
 
         /// <summary>
@@ -77,10 +77,10 @@ namespace FUnity.Stage
                 return;
             }
 
-            displayName = definition.DisplayName;
-            sprite = definition.Sprite;
-            size = definition.Size;
-            initialPosition = definition.InitialPosition;
+            m_displayName = definition.DisplayName;
+            m_sprite = definition.Sprite;
+            m_size = definition.Size;
+            m_initialPosition = definition.InitialPosition;
         }
 
         /// <summary>
@@ -88,19 +88,19 @@ namespace FUnity.Stage
         /// </summary>
         public void SetSprite(Sprite? newSprite)
         {
-            sprite = newSprite;
-            if (_visualElement != null)
+            m_sprite = newSprite;
+            if (m_visualElement != null)
             {
                 if (newSprite != null)
                 {
-                    _visualElement.style.backgroundImage = new StyleBackground(newSprite);
-                    _visualElement.style.unityBackgroundImageTintColor = new StyleColor(Color.white);
-                    _visualElement.style.backgroundColor = new StyleColor(Color.clear);
+                    m_visualElement.style.backgroundImage = new StyleBackground(newSprite);
+                    m_visualElement.style.unityBackgroundImageTintColor = new StyleColor(Color.white);
+                    m_visualElement.style.backgroundColor = new StyleColor(Color.clear);
                 }
                 else
                 {
-                    _visualElement.style.backgroundImage = new StyleBackground { keyword = StyleKeyword.Null };
-                    _visualElement.style.backgroundColor = new StyleColor(new Color(0.8f, 0.2f, 0.2f));
+                    m_visualElement.style.backgroundImage = new StyleBackground { keyword = StyleKeyword.Null };
+                    m_visualElement.style.backgroundColor = new StyleColor(new Color(0.8f, 0.2f, 0.2f));
                 }
             }
         }
@@ -110,29 +110,29 @@ namespace FUnity.Stage
         /// </summary>
         public void MoveTo(Vector2 position)
         {
-            _position = position;
-            if (_visualElement != null)
+            m_position = position;
+            if (m_visualElement != null)
             {
-                _visualElement.style.left = position.x;
-                _visualElement.style.top = position.y;
+                m_visualElement.style.left = position.x;
+                m_visualElement.style.top = position.y;
             }
         }
 
         /// <summary>
         /// Move by the given delta (in pixels).
         /// </summary>
-        public void MoveBy(Vector2 delta) => MoveTo(_position + delta);
+        public void MoveBy(Vector2 delta) => MoveTo(m_position + delta);
 
         /// <summary>
         /// Resize the sprite visual.
         /// </summary>
         public void SetSize(Vector2 newSize)
         {
-            size = newSize;
-            if (_visualElement != null)
+            m_size = newSize;
+            if (m_visualElement != null)
             {
-                _visualElement.style.width = newSize.x;
-                _visualElement.style.height = newSize.y;
+                m_visualElement.style.width = newSize.x;
+                m_visualElement.style.height = newSize.y;
             }
         }
 
@@ -143,21 +143,21 @@ namespace FUnity.Stage
                 return;
             }
 
-            _visualElement ??= CreateVisualElement();
-            if (_visualElement.parent != stageRoot)
+            m_visualElement ??= CreateVisualElement();
+            if (m_visualElement.parent != stageRoot)
             {
-                _visualElement.RemoveFromHierarchy();
-                stageRoot.Add(_visualElement);
+                m_visualElement.RemoveFromHierarchy();
+                stageRoot.Add(m_visualElement);
             }
 
-            MoveTo(_position);
+            MoveTo(m_position);
         }
 
         internal void DetachFromStage()
         {
-            if (_visualElement != null)
+            if (m_visualElement != null)
             {
-                _visualElement.RemoveFromHierarchy();
+                m_visualElement.RemoveFromHierarchy();
             }
         }
 
@@ -165,10 +165,10 @@ namespace FUnity.Stage
         {
             var element = new VisualElement { name = DisplayName };
             element.style.position = UnityEngine.UIElements.Position.Absolute;
-            element.style.width = size.x;
-            element.style.height = size.y;
-            element.style.left = _position.x;
-            element.style.top = _position.y;
+            element.style.width = m_size.x;
+            element.style.height = m_size.y;
+            element.style.left = m_position.x;
+            element.style.top = m_position.y;
             element.style.borderTopLeftRadius = 8f;
             element.style.borderTopRightRadius = 8f;
             element.style.borderBottomLeftRadius = 8f;
@@ -183,9 +183,9 @@ namespace FUnity.Stage
             element.style.borderLeftColor = new StyleColor(new Color(0.2f, 0.2f, 0.24f));
             element.style.borderRightColor = new StyleColor(new Color(0.2f, 0.2f, 0.24f));
 
-            if (sprite != null)
+            if (m_sprite != null)
             {
-                element.style.backgroundImage = new StyleBackground(sprite);
+                element.style.backgroundImage = new StyleBackground(m_sprite);
                 element.style.unityBackgroundImageTintColor = new StyleColor(Color.white);
             }
             else
@@ -204,7 +204,7 @@ namespace FUnity.Stage
             nameLabel.style.unityTextOutlineWidth = 0.2f;
             element.Add(nameLabel);
 
-            _visualElement = element;
+            m_visualElement = element;
             return element;
         }
     }

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteDefinition.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteDefinition.cs
@@ -9,30 +9,30 @@ namespace FUnity.Stage
     public sealed class StageSpriteDefinition : ScriptableObject
     {
         [SerializeField]
-        private string displayName = "Sprite";
+        private string m_displayName = "Sprite";
 
         [SerializeField]
-        private Sprite? sprite;
+        private Sprite? m_sprite;
 
         [SerializeField]
-        private Vector2 size = new Vector2(128f, 128f);
+        private Vector2 m_size = new Vector2(128f, 128f);
 
         [SerializeField]
-        private Vector2 initialPosition = new Vector2(120f, 120f);
+        private Vector2 m_initialPosition = new Vector2(120f, 120f);
 
-        public string DisplayName => string.IsNullOrWhiteSpace(displayName) ? name : displayName;
-        public Sprite? Sprite => sprite;
-        public Vector2 Size => size;
-        public Vector2 InitialPosition => initialPosition;
+        public string DisplayName => string.IsNullOrWhiteSpace(m_displayName) ? name : m_displayName;
+        public Sprite? Sprite => m_sprite;
+        public Vector2 Size => m_size;
+        public Vector2 InitialPosition => m_initialPosition;
 
         /// <summary>
         /// Utility method called by editor tools when generating new definitions.
         /// </summary>
         public void Initialize(Sprite newSprite, string friendlyName)
         {
-            sprite = newSprite;
-            displayName = string.IsNullOrWhiteSpace(friendlyName) ? newSprite.name : friendlyName;
-            size = new Vector2(newSprite.rect.width, newSprite.rect.height);
+            m_sprite = newSprite;
+            m_displayName = string.IsNullOrWhiteSpace(friendlyName) ? newSprite.name : friendlyName;
+            m_size = new Vector2(newSprite.rect.width, newSprite.rect.height);
         }
     }
 }


### PR DESCRIPTION
## Summary
- rename private member fields across runtime, actor, and definition classes to use the m_ prefix
- update editor tools to follow the same member-variable naming convention

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e448af3aec832ba3dd70931585a212