### PR TITLE
Add XML documentation comments to stage and paint tools

### DIFF
--- a/FUnity/Assets/FUnity/Editor/PaintToSprite.cs
+++ b/FUnity/Assets/FUnity/Editor/PaintToSprite.cs
@@ -4,17 +4,26 @@ using System.IO;
 using FUnity.Stage;
 
 namespace FUnity.Editor {
+    /// <summary>
+    /// Provides a simple painting canvas that exports the result as a sprite asset and stage definition.
+    /// </summary>
     public class PaintToSprite : EditorWindow {
         private Texture2D m_canvasTexture;
         private int m_canvasSize = 256;
 
         [MenuItem("FUnity/Paint & Save as Sprite")]
+        /// <summary>
+        /// Opens the paint window from the Unity menu.
+        /// </summary>
         public static void ShowWindow() {
             var window = GetWindow<PaintToSprite>();
             window.titleContent = new GUIContent("Paint to Sprite");
             window.Show();
         }
 
+        /// <summary>
+        /// Creates the painting texture when the window is enabled.
+        /// </summary>
         private void OnEnable() {
             if (m_canvasTexture == null) {
                 m_canvasTexture = new Texture2D(m_canvasSize, m_canvasSize, TextureFormat.RGBA32, false);
@@ -22,6 +31,9 @@ namespace FUnity.Editor {
             }
         }
 
+        /// <summary>
+        /// Draws the painting UI and handles button interactions.
+        /// </summary>
         private void OnGUI() {
             GUILayout.Label("🎨 Draw your Sprite", EditorStyles.boldLabel);
 
@@ -36,6 +48,9 @@ namespace FUnity.Editor {
             if (GUILayout.Button("Save as Sprite")) SaveAsSprite();
         }
 
+        /// <summary>
+        /// Processes mouse dragging to draw pixels onto the canvas texture.
+        /// </summary>
         private void HandleMouse(Rect area) {
             Event e = Event.current;
             if (e.type == EventType.MouseDrag && area.Contains(e.mousePosition)) {
@@ -47,6 +62,9 @@ namespace FUnity.Editor {
             }
         }
 
+        /// <summary>
+        /// Resets every pixel in the canvas texture to transparent.
+        /// </summary>
         private void ClearCanvas() {
             Color[] pixels = new Color[m_canvasSize * m_canvasSize];
             for (int i = 0; i < pixels.Length; i++) pixels[i] = Color.clear;
@@ -54,6 +72,9 @@ namespace FUnity.Editor {
             m_canvasTexture.Apply();
         }
 
+        /// <summary>
+        /// Saves the current canvas as a PNG and configures it for use as a sprite.
+        /// </summary>
         private void SaveAsSprite() {
             string path = EditorUtility.SaveFilePanel("Save Sprite", "Assets", "MyDrawing", "png");
             if (string.IsNullOrEmpty(path)) return;
@@ -99,6 +120,9 @@ namespace FUnity.Editor {
             }
         }
 
+        /// <summary>
+        /// Generates a StageSpriteDefinition asset that references the newly created sprite.
+        /// </summary>
         private static void CreateStageSpriteDefinition(Sprite sprite, string spriteAssetPath) {
             string directory = Path.GetDirectoryName(spriteAssetPath);
             if (string.IsNullOrEmpty(directory)) return;

--- a/FUnity/Assets/FUnity/Editor/PaintWindow.cs
+++ b/FUnity/Assets/FUnity/Editor/PaintWindow.cs
@@ -2,6 +2,9 @@
 using UnityEditor;
 
 namespace FUnity.Editor {
+    /// <summary>
+    /// Basic painting window used for quickly sketching textures inside the editor.
+    /// </summary>
     public class PaintWindow : EditorWindow {
         private Texture2D m_canvasTexture;
         private Color m_drawColor = Color.black;
@@ -9,12 +12,18 @@ namespace FUnity.Editor {
         private int m_canvasSize = 256;
 
         [MenuItem("FUnity/Paint Window")]
+        /// <summary>
+        /// Opens the paint tool window from the Unity editor menu.
+        /// </summary>
         public static void ShowWindow() {
             var window = GetWindow<PaintWindow>();
             window.titleContent = new GUIContent("FUnity Paint");
             window.Show();
         }
 
+        /// <summary>
+        /// Allocates the texture used as the drawing canvas when the window is enabled.
+        /// </summary>
         private void OnEnable() {
             if (m_canvasTexture == null) {
                 m_canvasTexture = new Texture2D(m_canvasSize, m_canvasSize, TextureFormat.RGBA32, false);
@@ -22,6 +31,9 @@ namespace FUnity.Editor {
             }
         }
 
+        /// <summary>
+        /// Renders the painting interface and handles user interactions.
+        /// </summary>
         private void OnGUI() {
             GUILayout.Label("🎨 FUnity Paint Tool", EditorStyles.boldLabel);
 
@@ -40,6 +52,9 @@ namespace FUnity.Editor {
             }
         }
 
+        /// <summary>
+        /// Converts mouse drags into pixel updates on the canvas.
+        /// </summary>
         private void HandleMouseInput(Rect drawArea) {
             Event e = Event.current;
             if (e.type == EventType.MouseDrag && drawArea.Contains(e.mousePosition)) {
@@ -55,12 +70,18 @@ namespace FUnity.Editor {
             }
         }
 
+        /// <summary>
+        /// Colors a single pixel on the canvas texture using the active draw color.
+        /// </summary>
         private void DrawPixel(Vector2Int pos) {
             if (pos.x < 0 || pos.x >= m_canvasSize || pos.y < 0 || pos.y >= m_canvasSize) return;
             m_canvasTexture.SetPixel(pos.x, pos.y, m_drawColor);
             m_canvasTexture.Apply();
         }
 
+        /// <summary>
+        /// Fills the canvas with white pixels to start a new drawing.
+        /// </summary>
         private void ClearCanvas() {
             Color[] pixels = new Color[m_canvasSize * m_canvasSize];
             for (int i = 0; i < pixels.Length; i++) pixels[i] = Color.white;

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageBootstrapper.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageBootstrapper.cs
@@ -11,6 +11,9 @@ namespace FUnity.Stage
     public static class StageBootstrapper
     {
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
+        /// <summary>
+        /// Guarantees that the stage GameObject exists after a scene has finished loading.
+        /// </summary>
         private static void EnsureStage()
         {
             if (Object.FindObjectOfType<StageRuntime>() != null)

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageRuntime.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageRuntime.cs
@@ -28,6 +28,9 @@ namespace FUnity.Stage
         /// </summary>
         public Vector2 StageSize => m_stageRoot?.contentRect.size ?? new Vector2(960f, 540f);
 
+        /// <summary>
+        /// Initializes the runtime instance, loads the layout assets and caches key references.
+        /// </summary>
         private void Awake()
         {
             if (Instance != null && Instance != this)
@@ -43,12 +46,18 @@ namespace FUnity.Stage
             CacheLayoutReferences();
         }
 
+        /// <summary>
+        /// Hooks up existing actors and refreshes the on-screen sprite list when the component activates.
+        /// </summary>
         private void OnEnable()
         {
             RegisterExistingActors();
             RefreshSpriteList();
         }
 
+        /// <summary>
+        /// Cleans up registered actors and releases the singleton instance when the component is disabled.
+        /// </summary>
         private void OnDisable()
         {
             foreach (var actor in m_actors)
@@ -85,6 +94,9 @@ namespace FUnity.Stage
             return actor;
         }
 
+        /// <summary>
+        /// Adds an actor to the runtime so it can be rendered and tracked by the stage.
+        /// </summary>
         internal void RegisterActor(StageSpriteActor actor)
         {
             if (m_actors.Contains(actor))
@@ -103,6 +115,9 @@ namespace FUnity.Stage
             RefreshSpriteList();
         }
 
+        /// <summary>
+        /// Removes an actor from the runtime, ensuring it is detached from the visual tree.
+        /// </summary>
         internal void UnregisterActor(StageSpriteActor actor)
         {
             if (m_actors.Remove(actor))
@@ -112,6 +127,9 @@ namespace FUnity.Stage
             }
         }
 
+        /// <summary>
+        /// Loads the UXML/USS resources that define the stage layout and styling.
+        /// </summary>
         private void LoadLayout()
         {
             var root = m_document.rootVisualElement;
@@ -136,6 +154,9 @@ namespace FUnity.Stage
             root.styleSheets.Add(styleSheet);
         }
 
+        /// <summary>
+        /// Queries and stores the key visual elements required for stage interaction.
+        /// </summary>
         private void CacheLayoutReferences()
         {
             var root = m_document.rootVisualElement;
@@ -152,6 +173,9 @@ namespace FUnity.Stage
             }
         }
 
+        /// <summary>
+        /// Finds StageSpriteActor components already present in the hierarchy and registers them.
+        /// </summary>
         private void RegisterExistingActors()
         {
             var existingActors = GetComponentsInChildren<StageSpriteActor>(true);
@@ -161,6 +185,9 @@ namespace FUnity.Stage
             }
         }
 
+        /// <summary>
+        /// Rebuilds the UI list that mirrors the currently registered sprite actors.
+        /// </summary>
         private void RefreshSpriteList()
         {
             if (m_spriteList == null)

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteActor.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteActor.cs
@@ -43,11 +43,17 @@ namespace FUnity.Stage
 
         internal bool HasSprite => m_sprite != null;
 
+        /// <summary>
+        /// Initializes the cached position so the sprite starts at its configured coordinates.
+        /// </summary>
         private void Awake()
         {
             m_position = m_initialPosition;
         }
 
+        /// <summary>
+        /// Registers the actor with the active stage runtime when the component becomes enabled.
+        /// </summary>
         private void OnEnable()
         {
             m_runtime = StageRuntime.Instance;
@@ -57,6 +63,9 @@ namespace FUnity.Stage
             }
         }
 
+        /// <summary>
+        /// Unregisters the actor from the runtime to avoid lingering references when disabled.
+        /// </summary>
         private void OnDisable()
         {
             if (m_runtime != null)
@@ -136,6 +145,9 @@ namespace FUnity.Stage
             }
         }
 
+        /// <summary>
+        /// Ensures the actor has a visual element and attaches it to the provided stage root.
+        /// </summary>
         internal void AttachToStage(VisualElement stageRoot)
         {
             if (stageRoot == null)
@@ -153,6 +165,9 @@ namespace FUnity.Stage
             MoveTo(m_position);
         }
 
+        /// <summary>
+        /// Removes the visual element from the hierarchy without destroying the component.
+        /// </summary>
         internal void DetachFromStage()
         {
             if (m_visualElement != null)
@@ -161,6 +176,9 @@ namespace FUnity.Stage
             }
         }
 
+        /// <summary>
+        /// Creates the UI Toolkit visual representation for the sprite actor.
+        /// </summary>
         private VisualElement CreateVisualElement()
         {
             var element = new VisualElement { name = DisplayName };


### PR DESCRIPTION
## Summary
- document the stage bootstrapper and runtime helper methods with XML comments
- expand StageSpriteActor documentation for lifecycle and stage interaction helpers
- add XML doc comments to the paint editor windows for clarity

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e44a09536c832b81505173ac3a40eb