### PR TITLE
Translate C# XML comments to Japanese

### DIFF
--- a/FUnity/Assets/FUnity/Editor/PaintToSprite.cs
+++ b/FUnity/Assets/FUnity/Editor/PaintToSprite.cs
@@ -5,7 +5,7 @@ using FUnity.Stage;
 
 namespace FUnity.Editor {
     /// <summary>
-    /// Provides a simple painting canvas that exports the result as a sprite asset and stage definition.
+    /// スプライトアセットとステージ定義として書き出せるシンプルなペイントキャンバスを提供します。
     /// </summary>
     public class PaintToSprite : EditorWindow {
         private Texture2D m_canvasTexture;
@@ -13,7 +13,7 @@ namespace FUnity.Editor {
 
         [MenuItem("FUnity/Paint & Save as Sprite")]
         /// <summary>
-        /// Opens the paint window from the Unity menu.
+        /// Unity メニューからペイントウィンドウを開きます。
         /// </summary>
         public static void ShowWindow() {
             var window = GetWindow<PaintToSprite>();
@@ -22,7 +22,7 @@ namespace FUnity.Editor {
         }
 
         /// <summary>
-        /// Creates the painting texture when the window is enabled.
+        /// ウィンドウが有効化された際にペイント用テクスチャを作成します。
         /// </summary>
         private void OnEnable() {
             if (m_canvasTexture == null) {
@@ -32,7 +32,7 @@ namespace FUnity.Editor {
         }
 
         /// <summary>
-        /// Draws the painting UI and handles button interactions.
+        /// ペイント用 UI を描画し、ボタン操作を処理します。
         /// </summary>
         private void OnGUI() {
             GUILayout.Label("🎨 Draw your Sprite", EditorStyles.boldLabel);
@@ -49,7 +49,7 @@ namespace FUnity.Editor {
         }
 
         /// <summary>
-        /// Processes mouse dragging to draw pixels onto the canvas texture.
+        /// マウスドラッグを処理してキャンバステクスチャにピクセルを描画します。
         /// </summary>
         private void HandleMouse(Rect area) {
             Event e = Event.current;
@@ -63,7 +63,7 @@ namespace FUnity.Editor {
         }
 
         /// <summary>
-        /// Resets every pixel in the canvas texture to transparent.
+        /// キャンバステクスチャのすべてのピクセルを透明でリセットします。
         /// </summary>
         private void ClearCanvas() {
             Color[] pixels = new Color[m_canvasSize * m_canvasSize];
@@ -73,7 +73,7 @@ namespace FUnity.Editor {
         }
 
         /// <summary>
-        /// Saves the current canvas as a PNG and configures it for use as a sprite.
+        /// 現在のキャンバスを PNG として保存し、スプライトとして利用できるよう設定します。
         /// </summary>
         private void SaveAsSprite() {
             string path = EditorUtility.SaveFilePanel("Save Sprite", "Assets", "MyDrawing", "png");
@@ -121,7 +121,7 @@ namespace FUnity.Editor {
         }
 
         /// <summary>
-        /// Generates a StageSpriteDefinition asset that references the newly created sprite.
+        /// 生成したスプライトを参照する StageSpriteDefinition アセットを生成します。
         /// </summary>
         private static void CreateStageSpriteDefinition(Sprite sprite, string spriteAssetPath) {
             string directory = Path.GetDirectoryName(spriteAssetPath);

--- a/FUnity/Assets/FUnity/Editor/PaintWindow.cs
+++ b/FUnity/Assets/FUnity/Editor/PaintWindow.cs
@@ -3,7 +3,7 @@ using UnityEditor;
 
 namespace FUnity.Editor {
     /// <summary>
-    /// Basic painting window used for quickly sketching textures inside the editor.
+    /// エディター内で素早くテクスチャを描ける基本的なペイントウィンドウです。
     /// </summary>
     public class PaintWindow : EditorWindow {
         private Texture2D m_canvasTexture;
@@ -13,7 +13,7 @@ namespace FUnity.Editor {
 
         [MenuItem("FUnity/Paint Window")]
         /// <summary>
-        /// Opens the paint tool window from the Unity editor menu.
+        /// Unity エディターのメニューからペイントツールウィンドウを開きます。
         /// </summary>
         public static void ShowWindow() {
             var window = GetWindow<PaintWindow>();
@@ -22,7 +22,7 @@ namespace FUnity.Editor {
         }
 
         /// <summary>
-        /// Allocates the texture used as the drawing canvas when the window is enabled.
+        /// ウィンドウが有効化された際に描画用キャンバステクスチャを確保します。
         /// </summary>
         private void OnEnable() {
             if (m_canvasTexture == null) {
@@ -32,7 +32,7 @@ namespace FUnity.Editor {
         }
 
         /// <summary>
-        /// Renders the painting interface and handles user interactions.
+        /// ペイント用インターフェースを描画し、ユーザー操作を処理します。
         /// </summary>
         private void OnGUI() {
             GUILayout.Label("🎨 FUnity Paint Tool", EditorStyles.boldLabel);
@@ -53,7 +53,7 @@ namespace FUnity.Editor {
         }
 
         /// <summary>
-        /// Converts mouse drags into pixel updates on the canvas.
+        /// マウスドラッグをキャンバス上のピクセル更新に変換します。
         /// </summary>
         private void HandleMouseInput(Rect drawArea) {
             Event e = Event.current;
@@ -71,7 +71,7 @@ namespace FUnity.Editor {
         }
 
         /// <summary>
-        /// Colors a single pixel on the canvas texture using the active draw color.
+        /// 選択中の描画色でキャンバステクスチャの単一ピクセルを塗ります。
         /// </summary>
         private void DrawPixel(Vector2Int pos) {
             if (pos.x < 0 || pos.x >= m_canvasSize || pos.y < 0 || pos.y >= m_canvasSize) return;
@@ -80,7 +80,7 @@ namespace FUnity.Editor {
         }
 
         /// <summary>
-        /// Fills the canvas with white pixels to start a new drawing.
+        /// 新しい描画を始められるようキャンバスを白で塗りつぶします。
         /// </summary>
         private void ClearCanvas() {
             Color[] pixels = new Color[m_canvasSize * m_canvasSize];

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageBootstrapper.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageBootstrapper.cs
@@ -4,15 +4,15 @@ using UnityEngine.UIElements;
 namespace FUnity.Stage
 {
     /// <summary>
-    /// Ensures that a UI Toolkit based stage is available whenever a scene is loaded.
-    /// The bootstrapper is executed automatically (both in Play Mode and builds) and
-    /// spawns a dedicated GameObject with an UIDocument + StageRuntime pair.
+    /// シーンがロードされるたびに UI Toolkit ベースのステージが利用可能になるよう保証します。
+    /// ブートストラッパーは（プレイモードとビルドの両方で）自動実行され、
+    /// UIDocument と StageRuntime を備えた専用の GameObject を生成します。
     /// </summary>
     public static class StageBootstrapper
     {
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         /// <summary>
-        /// Guarantees that the stage GameObject exists after a scene has finished loading.
+        /// シーンの読み込み完了後にステージ用 GameObject が存在することを保証します。
         /// </summary>
         private static void EnsureStage()
         {

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageRuntime.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageRuntime.cs
@@ -5,9 +5,9 @@ using UnityEngine.UIElements;
 namespace FUnity.Stage
 {
     /// <summary>
-    /// Builds and manages the Scratch-like workspace using Unity UI Toolkit.
-    /// The runtime creates a two-column layout: a stage on the left and helper panels on the right.
-    /// Stage sprites are managed via <see cref="StageSpriteActor"/> instances that Visual Scripting can control.
+    /// Unity UI Toolkit を用いてスクラッチ風ワークスペースを構築し管理します。
+    /// ランタイムは左にステージ、右に補助パネルを持つ二列レイアウトを生成します。
+    /// ステージ上のスプライトは Visual Scripting から操作できる <see cref="StageSpriteActor"/> インスタンスで管理されます。
     /// </summary>
     [RequireComponent(typeof(UIDocument))]
     public sealed class StageRuntime : MonoBehaviour
@@ -24,12 +24,12 @@ namespace FUnity.Stage
         public static StageRuntime? Instance { get; private set; }
 
         /// <summary>
-        /// Width/height of the current stage content rectangle.
+        /// 現在のステージ表示領域の幅と高さを返します。
         /// </summary>
         public Vector2 StageSize => m_stageRoot?.contentRect.size ?? new Vector2(960f, 540f);
 
         /// <summary>
-        /// Initializes the runtime instance, loads the layout assets and caches key references.
+        /// ランタイムを初期化し、レイアウトアセットの読み込みと主要参照のキャッシュを行います。
         /// </summary>
         private void Awake()
         {
@@ -47,7 +47,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Hooks up existing actors and refreshes the on-screen sprite list when the component activates.
+        /// コンポーネントが有効化された際に既存のアクターを登録し、画面上のスプライト一覧を更新します。
         /// </summary>
         private void OnEnable()
         {
@@ -56,7 +56,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Cleans up registered actors and releases the singleton instance when the component is disabled.
+        /// コンポーネントが無効化されたときに登録済みアクターを後処理し、シングルトンを解放します。
         /// </summary>
         private void OnDisable()
         {
@@ -73,8 +73,8 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Instantiate a new sprite actor on the stage at runtime.
-        /// This method is designed to be called from Visual Scripting graphs.
+        /// ランタイム中にステージへ新しいスプライトアクターを生成します。
+        /// Visual Scripting のグラフから呼び出せるよう設計されています。
         /// </summary>
         public StageSpriteActor? SpawnSprite(StageSpriteDefinition definition)
         {
@@ -95,7 +95,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Adds an actor to the runtime so it can be rendered and tracked by the stage.
+        /// アクターをランタイムへ登録し、ステージで描画・追跡できるようにします。
         /// </summary>
         internal void RegisterActor(StageSpriteActor actor)
         {
@@ -116,7 +116,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Removes an actor from the runtime, ensuring it is detached from the visual tree.
+        /// アクターをランタイムから外し、ビジュアルツリーから確実に切り離します。
         /// </summary>
         internal void UnregisterActor(StageSpriteActor actor)
         {
@@ -128,7 +128,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Loads the UXML/USS resources that define the stage layout and styling.
+        /// ステージのレイアウトとスタイルを定義する UXML/USS リソースを読み込みます。
         /// </summary>
         private void LoadLayout()
         {
@@ -155,7 +155,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Queries and stores the key visual elements required for stage interaction.
+        /// ステージ操作に必要な主要ビジュアル要素を検索して保持します。
         /// </summary>
         private void CacheLayoutReferences()
         {
@@ -174,7 +174,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Finds StageSpriteActor components already present in the hierarchy and registers them.
+        /// 階層内に既に存在する StageSpriteActor コンポーネントを見つけて登録します。
         /// </summary>
         private void RegisterExistingActors()
         {
@@ -186,7 +186,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Rebuilds the UI list that mirrors the currently registered sprite actors.
+        /// 登録されているスプライトアクターを反映した UI リストを再構築します。
         /// </summary>
         private void RefreshSpriteList()
         {

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteActor.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteActor.cs
@@ -4,8 +4,8 @@ using UnityEngine.UIElements;
 namespace FUnity.Stage
 {
     /// <summary>
-    /// Represents a sprite that is rendered inside the UI Toolkit stage.
-    /// Public API is intentionally simple so it can be consumed directly from Visual Scripting graphs.
+    /// UI Toolkit のステージ内で描画されるスプライトを表します。
+    /// 公開 API は Visual Scripting のグラフから直接扱えるよう意図的にシンプルにしています。
     /// </summary>
     [DisallowMultipleComponent]
     public sealed class StageSpriteActor : MonoBehaviour
@@ -27,12 +27,12 @@ namespace FUnity.Stage
         private StageRuntime? m_runtime;
 
         /// <summary>
-        /// Friendly name shown in the UI and Visual Scripting inspector.
+        /// UI と Visual Scripting インスペクターに表示されるわかりやすい名称です。
         /// </summary>
         public string DisplayName => string.IsNullOrWhiteSpace(m_displayName) ? name : m_displayName;
 
         /// <summary>
-        /// Current pixel position inside the stage (origin = top-left).
+        /// ステージ内での現在のピクセル座標（原点は左上）を返します。
         /// </summary>
         public Vector2 Position => m_position;
 
@@ -44,7 +44,7 @@ namespace FUnity.Stage
         internal bool HasSprite => m_sprite != null;
 
         /// <summary>
-        /// Initializes the cached position so the sprite starts at its configured coordinates.
+        /// キャッシュされた位置を初期化し、設定済み座標からスプライトを開始させます。
         /// </summary>
         private void Awake()
         {
@@ -52,7 +52,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Registers the actor with the active stage runtime when the component becomes enabled.
+        /// コンポーネントが有効化されたときにアクティブなステージランタイムへ登録します。
         /// </summary>
         private void OnEnable()
         {
@@ -64,7 +64,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Unregisters the actor from the runtime to avoid lingering references when disabled.
+        /// コンポーネントが無効化された際にランタイムから登録を解除し、参照の残存を防ぎます。
         /// </summary>
         private void OnDisable()
         {
@@ -77,7 +77,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Apply values from a definition ScriptableObject. Useful when spawned at runtime.
+        /// 定義用 ScriptableObject の値を適用します。ランタイム生成時に便利です。
         /// </summary>
         public void ApplyDefinition(StageSpriteDefinition definition)
         {
@@ -93,7 +93,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Set a new sprite texture at runtime.
+        /// ランタイム中に新しいスプライトテクスチャを設定します。
         /// </summary>
         public void SetSprite(Sprite? newSprite)
         {
@@ -115,7 +115,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Directly move to a specific pixel coordinate.
+        /// 指定したピクセル座標へ直接移動します。
         /// </summary>
         public void MoveTo(Vector2 position)
         {
@@ -128,12 +128,12 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Move by the given delta (in pixels).
+        /// 指定されたピクセル量だけ移動します。
         /// </summary>
         public void MoveBy(Vector2 delta) => MoveTo(m_position + delta);
 
         /// <summary>
-        /// Resize the sprite visual.
+        /// スプライトの見た目をリサイズします。
         /// </summary>
         public void SetSize(Vector2 newSize)
         {
@@ -146,7 +146,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Ensures the actor has a visual element and attaches it to the provided stage root.
+        /// アクターがビジュアル要素を保持していることを確認し、指定されたステージルートにアタッチします。
         /// </summary>
         internal void AttachToStage(VisualElement stageRoot)
         {
@@ -166,7 +166,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Removes the visual element from the hierarchy without destroying the component.
+        /// コンポーネントを破棄せずにビジュアル要素を階層から取り外します。
         /// </summary>
         internal void DetachFromStage()
         {
@@ -177,7 +177,7 @@ namespace FUnity.Stage
         }
 
         /// <summary>
-        /// Creates the UI Toolkit visual representation for the sprite actor.
+        /// スプライトアクター用の UI Toolkit ビジュアルを生成します。
         /// </summary>
         private VisualElement CreateVisualElement()
         {

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteDefinition.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageSpriteDefinition.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 namespace FUnity.Stage
 {
     /// <summary>
-    /// ScriptableObject used to describe a sprite entry that can be spawned on the stage.
+    /// ステージ上に出現させるスプライト情報を表す ScriptableObject です。
     /// </summary>
     [CreateAssetMenu(menuName = "FUnity/Stage Sprite", fileName = "StageSpriteDefinition")]
     public sealed class StageSpriteDefinition : ScriptableObject
@@ -26,7 +26,7 @@ namespace FUnity.Stage
         public Vector2 InitialPosition => m_initialPosition;
 
         /// <summary>
-        /// Utility method called by editor tools when generating new definitions.
+        /// エディターツールが新しい定義を生成するときに呼び出すユーティリティメソッドです。
         /// </summary>
         public void Initialize(Sprite newSprite, string friendlyName)
         {

--- a/FUnity/Assets/FUnity/Scripts/Stage/StageVisualScripting.cs
+++ b/FUnity/Assets/FUnity/Scripts/Stage/StageVisualScripting.cs
@@ -1,18 +1,18 @@
 namespace FUnity.Stage
 {
     /// <summary>
-    /// Lightweight helper to make it easier to reference the stage from Visual Scripting graphs.
+    /// Visual Scripting グラフからステージを参照しやすくする軽量なヘルパーです。
     /// </summary>
     public static class StageVisualScripting
     {
         /// <summary>
-        /// Returns the active stage runtime instance (if any).
+        /// アクティブなステージランタイムのインスタンスがあれば返します。
         /// </summary>
         public static StageRuntime? GetStage() => StageRuntime.Instance;
 
         /// <summary>
-        /// Spawn a sprite using a definition ScriptableObject.
-        /// Convenient wrapper that can be called directly from a Visual Scripting "Invoke Member" node.
+        /// 定義用 ScriptableObject を使ってスプライトを出現させます。
+        /// Visual Scripting の「Invoke Member」ノードから直接呼び出せる便利なラッパーです。
         /// </summary>
         public static StageSpriteActor? Spawn(StageSpriteDefinition definition) => StageRuntime.Instance?.SpawnSprite(definition);
     }


### PR DESCRIPTION
## Summary
- translate editor tool and stage runtime XMLドキュメントコメント to Japanese descriptions
- ensure all class and method documentation across stage-related scripts is now written in Japanese

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e44b069db8832b8c9f753d28157bf0