### PR TITLE
Handle WorkspaceHUD button lifecycle cleanly

### DIFF
--- a/Runtime/UI/WorkspaceHUD.cs
+++ b/Runtime/UI/WorkspaceHUD.cs
@@ -10,6 +10,7 @@ namespace FUnity.UI
     public sealed class WorkspaceHUD : MonoBehaviour
     {
         private UIDocument document;
+        private Button runButton;
 
         private void Awake()
         {
@@ -25,11 +26,25 @@ namespace FUnity.UI
                 return;
             }
 
-            var runButton = root.Q<Button>("run-button");
+            runButton = root.Q<Button>("run-button");
             if (runButton != null)
             {
-                runButton.clicked += () => Debug.Log("[FUnity] Run workspace requested.");
+                runButton.clicked += OnRunClicked;
             }
+        }
+
+        private void OnDisable()
+        {
+            if (runButton != null)
+            {
+                runButton.clicked -= OnRunClicked;
+                runButton = null;
+            }
+        }
+
+        private static void OnRunClicked()
+        {
+            Debug.Log("[FUnity] Run workspace requested.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- cache the Run button reference in WorkspaceHUD and wire it to a dedicated handler
- unsubscribe from the button click when the HUD disables to prevent duplicate registrations

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e4a19d3670832bbb7180876caa64cf