### PR TITLE
Add Scratch-inspired BlockElement UI component

### DIFF
--- a/Runtime/UI/BlockElement.cs
+++ b/Runtime/UI/BlockElement.cs
@@ -1,0 +1,70 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace FUnity.UI
+{
+    /// <summary>
+    /// Scratch-like rounded block element that can be reused from UXML.
+    /// </summary>
+    public class BlockElement : VisualElement
+    {
+        public new class UxmlFactory : UxmlFactory<BlockElement, UxmlTraits>
+        {
+        }
+
+        public new class UxmlTraits : VisualElement.UxmlTraits
+        {
+            private readonly UxmlStringAttributeDescription _textAttribute = new()
+            {
+                name = "text",
+                defaultValue = string.Empty
+            };
+
+            public override void Init(VisualElement ve, IUxmlAttributes bag, CreationContext cc)
+            {
+                base.Init(ve, bag, cc);
+
+                if (ve is BlockElement block)
+                {
+                    block.Text = _textAttribute.GetValueFromBag(bag, cc);
+                }
+            }
+        }
+
+        public static readonly string UssClassName = "block";
+        public static readonly string LabelUssClassName = "block__label";
+
+        private readonly Label _label;
+
+        public string Text
+        {
+            get => _label?.text ?? string.Empty;
+            set
+            {
+                if (_label != null)
+                {
+                    _label.text = value ?? string.Empty;
+                }
+            }
+        }
+
+        public BlockElement()
+        {
+            AddToClassList(UssClassName);
+
+            style.flexDirection = FlexDirection.Row;
+            style.justifyContent = Justify.Center;
+            style.alignItems = Align.Center;
+
+            _label = new Label
+            {
+                pickingMode = PickingMode.Ignore
+            };
+            _label.AddToClassList(LabelUssClassName);
+            _label.style.unityTextAlign = TextAnchor.MiddleCenter;
+            _label.style.flexGrow = 1f;
+
+            Add(_label);
+        }
+    }
+}

--- a/USS/block.uss
+++ b/USS/block.uss
@@ -1,0 +1,19 @@
+.block {
+    width: 160px;
+    height: 40px;
+    background-color: #FFCC00;
+    border-radius: 8px;
+    justify-content: center;
+    align-items: center;
+    color: black;
+    font-size: 14px;
+    font-weight: bold;
+    padding-left: 12px;
+    padding-right: 12px;
+}
+
+.block__label {
+    color: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+}

--- a/UXML/block.uxml
+++ b/UXML/block.uxml
@@ -1,0 +1,5 @@
+<ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:fui="FUnity.UI">
+    <ui:Style src="../USS/block.uss" />
+    <fui:BlockElement text="Move 10 Steps" />
+    <fui:BlockElement text="Turn 15 Degrees" />
+</ui:UXML>


### PR DESCRIPTION
## Summary
- add a reusable `BlockElement` VisualElement with configurable label text and UXML integration
- provide USS styling and UXML samples for the Scratch-like block UI

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e4a934239c832ba86c0a463fc558be