### PR TITLE
Add UIDocument to sample scene

### DIFF
--- a/Samples~/BasicScene/FUnitySample.unity
+++ b/Samples~/BasicScene/FUnitySample.unity
@@ -114,3 +114,52 @@ AudioListener:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 100000}
   m_Enabled: 1
+--- !u!1 &200000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 200001}
+  - component: {fileID: 200002}
+  m_Layer: 0
+  m_Name: FUnity UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &200001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 200000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &200002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 200000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0da8f2c7b7fcbaf48a8ba4a8988e85b2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_PanelSettings: {fileID: 0}
+  m_PanelSettingsFallback: {fileID: 0}
+  m_ParentSettings: 0
+  m_SortingOrder: 0
+  m_TargetTexture: {fileID: 0}
+  m_VisualTreeAsset: {fileID: 11400000, guid: 6f8f2d5c43c54c329fbc490c681e4d56, type: 3}

--- a/UXML/block.uxml.meta
+++ b/UXML/block.uxml.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f8f2d5c43c54c329fbc490c681e4d56
+ScriptedImporter:
+  internalIDToNameTable:
+  - first: 1344421583687837232
+    second: MainAsset
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a FUnity UI GameObject with a UIDocument component to the sample scene
- ensure the UIDocument references the package block.uxml asset
- add a meta file so the UXML asset can be referenced from the scene

## Testing
- not run (Unity editor not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4add3c3e8832b85395cfa8680a60d