### PR TITLE
Fix UIDocument component references in FUnity sample

### DIFF
--- a/Samples~/BasicScene/FUnityPanelSettings.asset
+++ b/Samples~/BasicScene/FUnityPanelSettings.asset
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9c9d7f913bb93b04e9ebcfdaf61c65f4, type: 3}
+  m_Name: FUnityPanelSettings
+  m_EditorClassIdentifier:
+  serializedVersion: 2
+  m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
+  m_ClearDepthStencil: 0
+  m_ColorClearMode: 0
+  m_ColorClearValue:
+    r: 0
+    g: 0
+    b: 0
+    a: 0
+  m_DepthClearValue: 1
+  m_PanelClearFlags: 0
+  m_ParentSettings: {fileID: 0}
+  m_ScaleMode: 1
+  m_ReferenceDpi: 96
+  m_FallbackDpi: 96
+  m_ReferenceResolution:
+    x: 1920
+    y: 1080
+  m_ScreenMatchMode: 0
+  m_Match: 0
+  m_SortingOrder: 0
+  m_TargetTexture: {fileID: 0}
+  m_ClearDepthStencilOnStart: 0
+  m_TargetDisplay: 0
+  m_PixelPerfect: 0
+  m_HasRenderTexture: 0
+  m_OffScreenRendering: 0
+  m_AllowExternalReadback: 0
+  m_Scale: 1
+  m_RuntimeShader: {fileID: 4800000, guid: 933532a4fcc9baf4fa526b5d15112fba, type: 3}
+  m_RuntimeWorldShader: {fileID: 4800000, guid: 933532a4fcc9baf4fa526b5d15112fba, type: 3}
+  m_AtlasWidth: 2048
+  m_AtlasHeight: 2048
+  m_AtlasBGColor: {r: 0, g: 0, b: 0, a: 0}
+  m_AtlasBlending: 0
+  m_AtlasOpacity: 1
+  m_VRCompatible: 0
+  m_ThemeStyleSheet: {fileID: 0}
+  m_ThemeUss: {fileID: 0}

--- a/Samples~/BasicScene/FUnityPanelSettings.asset.meta
+++ b/Samples~/BasicScene/FUnityPanelSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: eb7c6cb1b6b8480c8c91cde56543f148
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Samples~/BasicScene/FUnitySample.unity
+++ b/Samples~/BasicScene/FUnitySample.unity
@@ -154,12 +154,14 @@ MonoBehaviour:
   m_GameObject: {fileID: 200000}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0da8f2c7b7fcbaf48a8ba4a8988e85b2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_PanelSettings: {fileID: 0}
+  m_Script: {fileID: 11500000, guid: 3e08f811a5f6f4b49ae266b782ec8631, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_PanelSettings: {fileID: 11400000, guid: eb7c6cb1b6b8480c8c91cde56543f148, type: 2}
   m_PanelSettingsFallback: {fileID: 0}
   m_ParentSettings: 0
   m_SortingOrder: 0
   m_TargetTexture: {fileID: 0}
   m_VisualTreeAsset: {fileID: 11400000, guid: 6f8f2d5c43c54c329fbc490c681e4d56, type: 3}
+  m_StyleSheets:
+  - {fileID: 7433441135550727556, guid: 9a7e6a1d0b154dbcb5f222dfbdb19cb6, type: 3}

--- a/USS/block.uss.meta
+++ b/USS/block.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9a7e6a1d0b154dbcb5f222dfbdb19cb6
+ScriptedImporter:
+  internalIDToNameTable:
+  - first: 7433441135550727556
+    second: MainAsset
+  externalObjects: {}
+  serializedVersion: 2
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- replace the missing UIDocument component on the FUnity UI object so it loads block.uxml with the block stylesheet
- add a panel settings asset for the sample scene and hook it up to the UIDocument
- include the missing meta file for block.uss so the stylesheet can be referenced

## Testing
- not run (package modifications only)


------
https://chatgpt.com/codex/tasks/task_e_68e4b0a50f2c832b98da5e499fb7d8cd