### PR TITLE
Add runtime PanelSettings initializer

### DIFF
--- a/Runtime/UI/PanelSettingsInitializer.cs
+++ b/Runtime/UI/PanelSettingsInitializer.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using UnityEngine;
+using UnityEngine.UIElements;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace FUnity.UI
+{
+    public static class PanelSettingsInitializer
+    {
+        private const string ResourceName = "FUnityPanelSettings";
+        private const string ResourceDirectory = "Packages/com.papacoder.funity/Runtime/Resources";
+        private const string AssetPath = ResourceDirectory + "/" + ResourceName + ".asset";
+
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+        public static void EnsurePanelSettings()
+        {
+            var panelSettings = Resources.Load<PanelSettings>(ResourceName);
+            if (panelSettings == null)
+            {
+                panelSettings = ScriptableObject.CreateInstance<PanelSettings>();
+#if UNITY_EDITOR
+                if (!Directory.Exists(ResourceDirectory))
+                {
+                    Directory.CreateDirectory(ResourceDirectory);
+                }
+
+                AssetDatabase.CreateAsset(panelSettings, AssetPath);
+                AssetDatabase.SaveAssets();
+#endif
+            }
+
+            var uiDocuments = Object.FindObjectsOfType<UIDocument>();
+            if (uiDocuments == null || uiDocuments.Length == 0)
+            {
+                return;
+            }
+
+            foreach (var uiDocument in uiDocuments)
+            {
+                if (uiDocument != null && uiDocument.panelSettings == null)
+                {
+                    uiDocument.panelSettings = panelSettings;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a runtime initializer that creates and assigns a shared PanelSettings asset for UIDocuments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4b874e1d8832baf3dff73a325f568