### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,107 @@
+name: "🐛 バグ報告"
+description: "FUnity の不具合を報告する"
+title: "[Bug] "
+labels: ["bug"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ありがとうございます！再現できる情報があるほど、直すのが速くなります。
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 何が起きたかを1〜2行で
+      placeholder: "例: WhenGreenFlagClicked が2つあると片方しか動かない"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: 手順を番号で
+      placeholder: |
+        1. 新規プロジェクト作成
+        2. Actor を2つ作る
+        3. 両方に「緑の旗が押されたとき」を配置
+        4. 再生して旗を押す
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する動作
+      placeholder: "例: 2つのイベントが並行に動く"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の動作
+      placeholder: "例: 片方だけ動く / 例外が出る"
+    validations:
+      required: true
+
+  - type: input
+    id: unity_version
+    attributes:
+      label: Unity バージョン
+      placeholder: "例: 6000.0.xx / 2022.3.xx"
+    validations:
+      required: true
+
+  - type: input
+    id: funity_version
+    attributes:
+      label: FUnity のバージョン / commit
+      description: パッケージ導入方法と、可能ならコミットSHA
+      placeholder: "例: UPM git URL / v0.x / commit abcdefg"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: 発生環境
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Android
+        - iOS
+        - WebGL
+        - その他
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Consoleログ / スタックトレース
+      description: 可能なら全文（長い場合は要点でもOK）
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: スクショ / 動画 / 参考リンク
+      description: 画像をドラッグ&ドロップで貼れます
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 確認
+      options:
+        - label: "同じIssueが既に無いか検索しました"
+          required: true
+        - label: "最新のmain（または最新リリース）でも再現します"
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 質問・相談（Discussions 推奨）
+    url: https://github.com/oco777/FUnity/discussions
+    about: 仕様相談・使い方の質問・アイデア雑談はこちら（Issueはタスク管理用）
+  - name: セキュリティ報告
+    url: https://github.com/oco777/FUnity/security/policy
+    about: 脆弱性の報告は公開Issueではなくこちらへ

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,28 @@
+name: "📚 ドキュメント改善"
+description: "README / docs / チュートリアルの修正・追加"
+title: "[Docs] "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: target
+    attributes:
+      label: 対象ページ / ファイル
+      placeholder: "例: README.md / docs/spec.md / ブログ第10回"
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: 問題点
+      placeholder: "例: 手順がScratchとズレていて混乱する"
+    validations:
+      required: true
+
+  - type: textarea
+    id: fix
+    attributes:
+      label: 修正案
+      placeholder: "例: Scratchのブロック画像に合わせて文章を調整する"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: "✨ 機能要望"
+description: "FUnity に追加したい機能・改善案"
+title: "[Feat] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: 解決したい課題
+      description: なぜ必要か（教材として／ユーザー体験として）
+      placeholder: "例: 子どもがイベントの並行処理を理解できるようにしたい"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 提案（こうしたい）
+      placeholder: "例: 同種イベントが複数あっても全て並行実行される"
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: 対象範囲
+      description: 影響しそうな箇所
+      placeholder: "例: Visual Scripting Units / Runtime Event Bus / サンプルプロジェクト"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 優先度（希望）
+      options:
+        - P0: なるべく早く（教材が詰まる）
+        - P1: 近いうちに
+        - P2: 余裕があるとき
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: acceptance
+    attributes:
+      label: 受け入れ条件（例）
+      options:
+        - label: "仕様（docs/spec など）に追記される"
+        - label: "サンプル or チュートリアル記事に反映される"
+        - label: "テスト（可能なら）または検証手順が追加される"

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,18 @@
+name: "✅ タスク"
+description: "小さめの作業・リファクタ・雑務"
+title: "[Task] "
+labels: ["chore"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: やること
+      placeholder: "- [ ] 例: WhenGreenFlagClicked の並行実行を実装"
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: 補足
+      required: false


### PR DESCRIPTION
### Motivation
- Standardize issue intake to reduce missing information for bug reports, feature requests, docs fixes, and small tasks.
- Provide clear guidance and direct links to `Discussions` and `security` policy to route non-issue reports appropriately.

### Description
- Add issue forms configuration at `/.github/ISSUE_TEMPLATE/config.yml` with `contact_links` for Discussions and security reporting.
- Add a bug report form at `/.github/ISSUE_TEMPLATE/bug_report.yml` that collects summary, reproduction steps, environment, logs, and confirmations.
- Add feature request, docs improvement, and task templates at `/.github/ISSUE_TEMPLATE/feature_request.yml`, `/.github/ISSUE_TEMPLATE/docs.yml`, and `/.github/ISSUE_TEMPLATE/task.yml` respectively.
- Files were added and committed to the repository with the commit message `chore: add GitHub issue templates`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b82e608d8832b9100a0d36f022101)