### PR TITLE
chore: add .gitattributes to normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,39 @@
+# =========================
+# Text files: LF normalized
+# =========================
+* text=auto eol=lf
+
+# =========================
+# Unity / C# / UI Toolkit
+# =========================
+*.cs      text eol=lf
+*.uxml    text eol=lf
+*.uss     text eol=lf
+*.shader  text eol=lf
+*.compute text eol=lf
+*.meta    text eol=lf
+
+# =========================
+# Documentation / Config
+# =========================
+*.md      text eol=lf
+*.txt     text eol=lf
+*.json    text eol=lf
+*.yml     text eol=lf
+*.yaml    text eol=lf
+
+# =========================
+# Binary assets
+# =========================
+*.png     binary
+*.jpg     binary
+*.jpeg    binary
+*.gif     binary
+*.psd     binary
+*.wav     binary
+*.mp3     binary
+*.ogg     binary
+*.ttf     binary
+*.otf     binary
+*.fbx     binary
+*.unity   binary


### PR DESCRIPTION
### Motivation
- Enforce LF (`eol=lf`) as the canonical line ending and ensure Unity-related files and common docs/configs are handled correctly by Git.

### Description
- Add repository-root `.gitattributes` with `* text=auto eol=lf`, explicit `text eol=lf` rules for Unity/C#/UI Toolkit files (`*.cs`, `*.uxml`, `*.uss`, `*.shader`, `*.compute`, `*.meta`), rules for docs/config (`*.md`, `*.txt`, `*.json`, `*.yml`, `*.yaml`), and `binary` entries for image, audio, font, model and scene extensions (e.g. `*.png`, `*.wav`, `*.ttf`, `*.fbx`, `*.unity`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c2e12f2f8832bb6f7111aa8b6827a)